### PR TITLE
31: Allow parse_workflow_config_parameter is also accept the type int

### DIFF
--- a/src/omotes_sdk/internal/worker/params_dict.py
+++ b/src/omotes_sdk/internal/worker/params_dict.py
@@ -51,6 +51,22 @@ def parse_workflow_config_parameter(
         # `workflow_config[field_key]` according to the type checker. However, we have confirmed
         # the type already so we may cast it.
         result = cast(ParamsDictValue, maybe_value)
+    elif is_present and type(maybe_value) is float and expected_type is int:
+        # when the field value type is float but the Expected type is an integer,
+        # round the value to an integer and log the warning message
+        # if the non-rounded value is received.
+        rounded_maybe_value = round(maybe_value)
+        result = cast(ParamsDictValue, rounded_maybe_value)
+        if rounded_maybe_value != maybe_value:
+            logger.warning(
+                "%s field was passed in workflow configuration but as a %s instead of %s. "
+                "Rounding the field value from %s to %s.",
+                field_key,
+                of_type,
+                expected_type,
+                maybe_value,
+                result
+            )
     elif default_value:
         result = default_value
         if is_present and not isinstance(maybe_value, expected_type):

--- a/src/omotes_sdk/types.py
+++ b/src/omotes_sdk/types.py
@@ -1,4 +1,4 @@
 from typing import List, Union, Mapping
 
-ParamsDictValues = Union[List["ParamsDictValues"], "ParamsDict", None, float, str, bool]
+ParamsDictValues = Union[List["ParamsDictValues"], "ParamsDict", None, float, int, str, bool]
 ParamsDict = Mapping[str, ParamsDictValues]

--- a/unit_test/internal/worker/test_params_dict.py
+++ b/unit_test/internal/worker/test_params_dict.py
@@ -24,6 +24,22 @@ class TestModule(unittest.TestCase):
         expected_param = 1.0
         self.assertEqual(param, expected_param)
 
+    def test__parse_workflow_config_parameter__key_available_expect_int_but_get_float(self) -> None:
+        # Arrange
+        workflow_config = {"some-key": 1.4}
+        field_key = "some-key"
+        expected_type = int
+        default_value = 2.0
+
+        # Act
+        param = parse_workflow_config_parameter(
+            workflow_config, field_key, expected_type, default_value
+        )
+
+        # Assert
+        expected_param = 1
+        self.assertEqual(param, expected_param)
+
     def test__parse_workflow_config_parameter__key_unavailable_but_default(self) -> None:
         # Arrange
         workflow_config = {"no-key": 1.0}


### PR DESCRIPTION
- Added an additional `elif` condition in the parse_workflow_config_parameter() function to handle the case when the `expected_type` is `int`, but receives `float`.
- Added a corresponding test case.