### PR TITLE
71: Duration parameter now works with seconds instead of milliseconds…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 
 dependencies = [
     "aio-pika ~= 9.4.2",
-    "omotes-sdk-protocol ~= 0.1.4",
+    "omotes-sdk-protocol ~= 0.1.5",
     "pamqp ~= 3.3.0",
     "celery ~= 5.3.6",
     "typing-extensions ~= 4.11.0",

--- a/src/omotes_sdk/workflow_type.py
+++ b/src/omotes_sdk/workflow_type.py
@@ -763,6 +763,11 @@ class DurationParameter(WorkflowParameter):
         :return: class instance.
         """
         duration_params = ["default", "minimum", "maximum"]
+        args = {
+            "key_name": json_config["key_name"],
+            "title": json_config.get("title"),
+            "description": json_config.get("description"),
+        }
         for duration_param in duration_params:
             if duration_param in json_config and not isinstance(
                 json_config[duration_param], (int, float)
@@ -771,8 +776,10 @@ class DurationParameter(WorkflowParameter):
                     f"'{duration_param}' for DurationParameter must be a number in seconds:"
                     f" '{json_config[duration_param]}'"
                 )
+            elif duration_param in json_config:
+                args[duration_param] = timedelta(seconds=json_config[duration_param])
 
-        return cls(**json_config)
+        return cls(**args)
 
     @staticmethod
     def from_pb_value(value: PBStructCompatibleTypes) -> timedelta:

--- a/unit_test/test_workflow_type.py
+++ b/unit_test/test_workflow_type.py
@@ -183,7 +183,7 @@ class TestModule(unittest.TestCase):
             "float": 2.0,
             "int": 3.0,
             "datetime": datetime.fromisoformat("2019-01-01T01:00:00").timestamp(),
-            "duration": 3_615_000.0,
+            "duration": 3_615.0,
         }
 
         self.assertEqual(json_format.MessageToDict(converted), expected_converted)
@@ -297,7 +297,7 @@ class TestModule(unittest.TestCase):
         )
 
         # Assert
-        expected_param = timedelta(seconds=3.615)
+        expected_param = timedelta(hours=1, seconds=15)
         self.assertEqual(param, expected_param)
 
     def test__parse_workflow_config_parameter__key_available_expect_int_but_get_float(self) -> None:


### PR DESCRIPTION
… when packing to protobuf message and in json config. Also added a minimum and maximum field.