### PR TITLE
67 refactor implementation of left over job queues clean up

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ requires = [
 enabled = true
 
 [tool.pytest.ini_options]
-addopts = "--cov=omotes_sdk --cov-report html --cov-report term-missing --cov-fail-under 63"
+addopts = "--cov=omotes_sdk --cov-report html --cov-report term-missing --cov-fail-under 62"
 
 [tool.coverage.run]
 source = ["src"]

--- a/src/omotes_sdk/queue_names.py
+++ b/src/omotes_sdk/queue_names.py
@@ -82,11 +82,3 @@ class OmotesQueueNames:
         :return: The queue name.
         """
         return "request_available_workflows"
-
-    @staticmethod
-    def job_result_dead_letter_queue_name() -> str:
-        """Generate the job result dead letter queue name.
-
-        :return: The queue name.
-        """
-        return "job_result_message_dlq"

--- a/unit_test/internal/common/test_queue_message_ttl.py
+++ b/unit_test/internal/common/test_queue_message_ttl.py
@@ -1,12 +1,12 @@
 import unittest
 from datetime import timedelta
-from omotes_sdk.internal.common.broker_interface import QueueMessageTTLArguments
+from omotes_sdk.internal.common.broker_interface import QueueTTLArguments
 
 
 class TestQueueMessageTTLArguments(unittest.TestCase):
     def test__to_argument__no_arguments(self) -> None:
         # Arrange / Act
-        args = QueueMessageTTLArguments()
+        args = QueueTTLArguments()
 
         # Assert
         self.assertEqual(args.to_argument(), {})
@@ -16,7 +16,7 @@ class TestQueueMessageTTLArguments(unittest.TestCase):
         q_ttl = timedelta(seconds=60)
 
         # Act
-        args = QueueMessageTTLArguments(queue_ttl=q_ttl)
+        args = QueueTTLArguments(queue_ttl=q_ttl)
 
         # Assert
         self.assertEqual(args.to_argument(), {"x-expires": 60000})
@@ -27,7 +27,7 @@ class TestQueueMessageTTLArguments(unittest.TestCase):
 
         # Act / Assert
         with self.assertRaises(ValueError):
-            QueueMessageTTLArguments(queue_ttl=q_ttl).to_argument()
+            QueueTTLArguments(queue_ttl=q_ttl).to_argument()
 
     def test__to_argument__zero_queue_ttl(self) -> None:
         # Arrange
@@ -35,77 +35,4 @@ class TestQueueMessageTTLArguments(unittest.TestCase):
 
         # Act / Assert
         with self.assertRaises(ValueError):
-            QueueMessageTTLArguments(queue_ttl=q_ttl).to_argument()
-
-    def test__to_argument__message_ttl(self) -> None:
-        # Arrange
-        msg_ttl = timedelta(seconds=30)
-
-        # Act
-        args = QueueMessageTTLArguments(message_ttl=msg_ttl)
-
-        # Assert
-        self.assertEqual(args.to_argument(), {"x-message-ttl": 30000})
-
-    def test__to_argument__negative_message_ttl(self) -> None:
-        # Arrange
-        msg_ttl = timedelta(seconds=-30)
-
-        # Act / Assert
-        with self.assertRaises(ValueError):
-            QueueMessageTTLArguments(message_ttl=msg_ttl).to_argument()
-
-    def test__to_argument__message_ttl_larger_than_queue_ttl(self) -> None:
-        # Arrange
-        q_ttl = timedelta(seconds=30)
-        msg_ttl = timedelta(seconds=60)
-
-        # Act / Assert
-        with self.assertRaises(ValueError):
-            QueueMessageTTLArguments(
-                queue_ttl=q_ttl,
-                message_ttl=msg_ttl
-            ).to_argument()
-
-    def test__to_argument__dead_letter_routing_key(self) -> None:
-        # Arrange
-        dl_routing_key = "test-dlq"
-
-        # Act
-        args = QueueMessageTTLArguments(dead_letter_routing_key=dl_routing_key)
-
-        # Assert
-        self.assertEqual(args.to_argument(), {"x-dead-letter-routing-key": "test-dlq"})
-
-    def test__to_argument__dead_letter_exchange(self) -> None:
-        # Arrange
-        dl_exchange = "test-exchange"
-
-        # Act
-        args = QueueMessageTTLArguments(dead_letter_exchange=dl_exchange)
-
-        # Assert
-        self.assertEqual(args.to_argument(), {"x-dead-letter-exchange": "test-exchange"})
-
-    def test__to_argument__all_arguments(self) -> None:
-        # Arrange
-        q_ttl = timedelta(minutes=2)
-        msg_ttl = timedelta(minutes=1)
-        dl_routing_key = "test-dlq"
-        dl_exchange = "test-exchange"
-
-        # Act
-        args = QueueMessageTTLArguments(
-            queue_ttl=q_ttl,
-            message_ttl=msg_ttl,
-            dead_letter_routing_key=dl_routing_key,
-            dead_letter_exchange=dl_exchange
-        )
-
-        # Assert
-        self.assertEqual(args.to_argument(), {
-            "x-expires": 120000,
-            "x-message-ttl": 60000,
-            "x-dead-letter-routing-key": "test-dlq",
-            "x-dead-letter-exchange": "test-exchange"
-        })
+            QueueTTLArguments(queue_ttl=q_ttl).to_argument()


### PR DESCRIPTION
Related to issues: https://github.com/Project-OMOTES/omotes-sdk-python/issues/67, https://github.com/Project-OMOTES/omotes-system/issues/80

Removed job result dead letter queue, dead letter exchange, and message TTL implementation to avoid SDK client reconnection occurring after the job result message is already dead-lettered and the SDK client will be waiting infinitely.

Tested manually with the following scenarios

**1. Happy path**
1. The SDK client submits a job.
2. The job is finished, returned to the queue, and consumed by the SDK client.
3. All job queues are removed as intended.

**2. Immediate reconnect**
1. The SDK client submits a job
2. The job starts running, but the SDK client goes offline for 2 seconds (Queue TTL is activated).
3. The SDK client attempts to reconnect, first checking if queues still exist.
4. The queues still exist, the SDK client reconnects to the queues (Queue TTL is deactivated).
5. The job is finished, returned to the queue, and consumed by the SDK client.
6. All job queues are removed as intended.

**3. Reconnect after the job is finished**
1. The SDK client submits a job.
2. The job starts running, but the SDK client goes offline for 15 seconds (Queue TTL is activated).
3. The job is finished, returned to the queue, and waited to be consumed.
4. The SDK client attempts to reconnect, first checking if queues still exist.
5. The queues still exist, the SDK client reconnects to the queues (Queue TTL is deactivated).
6. **The SDK client consumes the job result message and removes only the job result queue. Job progress and status queues remain in RabbitMQ.**
7. **The job progress and status queues are removed after reaching their TTL.**

**4. Never reconnect**
1. The SDK client submits a job.
2. The job starts running, but the SDK client goes offline forever.
3. The job is finished, returned to the queue, and waited to be consumed.
4. The job messages are dropped silently and queues are removed after reaching queue TTL.

**5. Reconnect after queues have already expired**
1. The SDK client submits a job.
2. The job starts running, but the SDK client goes offline for a long period (longer than the provided TTL).
3. The job is finished, returned to the queue, and waited to be consumed.
4. The job messages are dropped silently and queues are removed after reaching queue TTL.
5. The SDK client attempts to reconnect, first checking if queues still exist.
6. The queues do not exist, reconnection is aborted and an error message is thrown to the SDK client.
![image](https://github.com/user-attachments/assets/2417e691-ad50-4153-bcad-c4888c8bf808)

